### PR TITLE
Add Husky to ensure everyone is running the same pre-commit hooks.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -20,5 +20,6 @@
         "extensions": [".js", ".jsx", ".ts", ".tsx"]
       }
     }
-  }
+  },
+  "ignorePatterns": ["webpack*"]
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         run: yarn --frozen-lockfile
 
       - name: 🚔 Run ESLint
-        run: yarn eslint --ext .ts .
+        run: yarn eslint
 
       - name: 💅🏼 Run Prettier
-        run: yarn prettier -c .
+        run: yarn prettier

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+yarn lint && yarn prettier

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",
-    "lint": "eslint --ext .ts ."
+    "lint": "eslint --max-warnings 0 --ignore-path .gitignore --ext .js,.ts,.tsx .",
+    "lint:fix": "eslint --fix --ignore-path .gitignore --ext .js,.ts,.tsx .",
+    "prettier": "prettier --list-different .",
+    "prettier:fix": "prettier --write .",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": {
@@ -84,7 +88,8 @@
     "prettier": "2.3.2",
     "style-loader": "^3.0.0",
     "ts-loader": "^9.2.2",
-    "typescript": "^4.0.2"
+    "typescript": "^4.0.2",
+    "husky": "^7.0.0"
   },
   "dependencies": {
     "@shopify/polaris": "^6.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3356,6 +3356,11 @@ human-signals@^2.1.0:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
+husky@^7.0.0:
+  version "7.0.1"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-7.0.1.tgz#579f4180b5da4520263e8713cc832942b48e1f1c"
+  integrity sha512-gceRaITVZ+cJH9sNHqx5tFwbzlLCVxtVZcusME8JYQ8Edy5mpGDOqD8QBCdMhpyo9a+JXddnujQ4rpY2Ff9SJA==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Also expand the set of Yarn commands to support running prettier and automated fixes for both ESLint and Prettier. With these changes, the linter and code formatter are unforgiving when attempting to commit. Fortunately, you can run `yarn prettier:fix` and `yarn lint:fix` to run any automated fixes. At which point, you can add the changes and try committing again.

If you find this too annoying, we can omit it. But, I think it'll help keep reduce churn in commits for the reasons outlined in #9.

Fixes #9.