### PR TITLE
Add tabs to show dump folders and its list of BGV files

### DIFF
--- a/src/components/BgvFileList.tsx
+++ b/src/components/BgvFileList.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { useState } from "react";
+
+import { Card, OptionList } from "@shopify/polaris";
+import { SeafoamNode } from "../types/RootFolder";
+
+interface Props {
+  listOfBgvFiles: {
+    name: string;
+    seafoamNodes: SeafoamNode[];
+  }[];
+}
+
+export default function BgvFileList(props: Props) {
+  const { listOfBgvFiles } = props;
+  const [selected, setSelected] = useState([]);
+  const mappedBgvFiles = listOfBgvFiles.map((bgvFile) => ({
+    value: bgvFile.name,
+    label: bgvFile.name,
+  }));
+
+  return (
+    <Card>
+      <OptionList
+        title="List of Bgv Files"
+        onChange={setSelected}
+        options={mappedBgvFiles}
+        selected={selected}
+      />
+    </Card>
+  );
+}

--- a/src/components/DumpFolderTabs.tsx
+++ b/src/components/DumpFolderTabs.tsx
@@ -1,26 +1,27 @@
 import * as React from "react";
 import { useCallback, useState } from "react";
-import { Card, Tabs } from '@shopify/polaris';
-import RootFolder from "../RootFolder";
 
-export default DumpFolderTabs;
+import { Card, Tabs } from "@shopify/polaris";
+import RootFolder from "../types/RootFolder";
+import BgvFileList from "./BgvFileList";
 
-function DumpFolderTabs() {
+export default function DumpFolderTabs() {
   const [selected, setSelected] = useState(0);
   const rootFolder = new RootFolder("file/path/to/dumps");
 
   const handleTabChange = useCallback(
     (selectedTabIndex) => setSelected(selectedTabIndex),
-    [],
+    []
   );
 
   const tabs = rootFolder.dumps;
+  const listOfBgvFiles = tabs[selected].methods;
 
   return (
     <Card>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <Card.Section title={tabs[selected].content}>
-          <p>Tab {tabs[selected].id} selected</p>
+          <BgvFileList listOfBgvFiles={listOfBgvFiles} />
         </Card.Section>
       </Tabs>
     </Card>

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -4,7 +4,11 @@ import { Page } from "@shopify/polaris";
 import DumpFolderTabs from "./DumpFolderTabs";
 
 const LeftPanel: React.FunctionComponent = () => {
-  return <Page title="Dump Panel"><DumpFolderTabs /></Page>;
+  return (
+    <Page title="Graal Dump Folders">
+      <DumpFolderTabs />
+    </Page>
+  );
 };
 
 export default LeftPanel;

--- a/src/types/RootFolder.ts
+++ b/src/types/RootFolder.ts
@@ -1,5 +1,9 @@
 export default class RootFolder {
-  dumps: { id: string, content: string; methods: { name: string; nodes: SeafoamNode[] }[] }[];
+  dumps: {
+    id: string;
+    content: string;
+    methods: { name: string; seafoamNodes: SeafoamNode[] }[];
+  }[];
   constructor(filepath: string) {
     this.dumps = [
       {
@@ -8,7 +12,7 @@ export default class RootFolder {
         methods: [
           {
             name: "TruffleHotSpotCompilation-17080[String#include?].bgv",
-            nodes: [
+            seafoamNodes: [
               new SeafoamNode(
                 "TruffleIR::String#include?()/Call Tree/Before Inline"
               ),
@@ -22,7 +26,7 @@ export default class RootFolder {
           },
           {
             name: "TruffleHotSpotCompilation-17080[String#include?]_1.bgv",
-            nodes: [
+            seafoamNodes: [
               new SeafoamNode(
                 "TruffleIR::String#include?()/Call Tree/Before Inline"
               ),
@@ -42,7 +46,7 @@ export default class RootFolder {
         methods: [
           {
             name: "TruffleHotSpotCompilation-11279[Array#size].bgv",
-            nodes: [
+            seafoamNodes: [
               new SeafoamNode(
                 "TruffleIR::Array#size()/Call Tree/Before Inline"
               ),
@@ -54,7 +58,7 @@ export default class RootFolder {
           },
           {
             name: "TruffleHotSpotCompilation-11279[Array#size]_1.bgv",
-            nodes: [
+            seafoamNodes: [
               new SeafoamNode(
                 "TruffleIR::Array#size()/Call Tree/Before Inline"
               ),
@@ -70,7 +74,7 @@ export default class RootFolder {
   }
 }
 
-class SeafoamNode {
+export class SeafoamNode {
   name: string;
   constructor(name: string) {
     this.name = name;


### PR DESCRIPTION
### Issue

~Some of https://github.com/Shopify/seafoam-gui/issues/17 but I don't think it's done yet. We still have the search bar, and the directory text bar.~

Closes https://github.com/Shopify/seafoam-gui/issues/17

### Changes
* Add tabs which shows the `graal_dump` folder name
* Under each tab is a list of BGV files (associated with a method)

Currently still using mock data. 

### Demo
![left bar](https://user-images.githubusercontent.com/25471753/126551197-cd836d71-a527-4089-bf75-01858723f25d.gif)
