### PR TITLE
Add filter method function with no results notifier

### DIFF
--- a/src/components/DumpFolderTabs.tsx
+++ b/src/components/DumpFolderTabs.tsx
@@ -2,11 +2,16 @@ import * as React from "react";
 import { useCallback, useEffect, useState } from "react";
 
 import { Card, Tabs } from "@shopify/polaris";
-import RootFolder from "../types/RootFolder";
+import RootFolder, { SeafoamNode } from "../types/RootFolder";
 import BgvFileList from "./BgvFileList";
 import { DirectoryLoadedPayload, IPCEvents } from "../events";
 
-export default function DumpFolderTabs() {
+interface Props {
+  methodFilter: string;
+}
+
+export default function DumpFolderTabs(props: Props) {
+  const methodFilter: string = props.methodFilter;
   const [selected, setSelected] = useState(0);
   const [rootFolder, setRootFolder] = useState<RootFolder>(
     new RootFolder("empty", [])
@@ -31,13 +36,25 @@ export default function DumpFolderTabs() {
   );
 
   const tabs = rootFolder.dumps;
-  const listOfBgvFiles = tabs[selected].methods;
+  const unfilteredList = tabs[selected].methods;
+
+  function finalListOfBgvFiles() {
+    const filteredList = unfilteredList.filter((query) =>
+      query.name.includes(methodFilter)
+    );
+    const filteredListWithNoResults =
+      filteredList.length == 0
+        ? [{ name: "No results found.", seafoamNodes: [new SeafoamNode("")] }]
+        : filteredList;
+
+    return methodFilter == "" ? unfilteredList : filteredListWithNoResults;
+  }
 
   return (
     <Card>
       <Tabs tabs={tabs} selected={selected} onSelect={handleTabChange}>
         <Card.Section title={tabs[selected].content}>
-          <BgvFileList listOfBgvFiles={listOfBgvFiles} />
+          <BgvFileList listOfBgvFiles={finalListOfBgvFiles()} />
         </Card.Section>
       </Tabs>
     </Card>

--- a/src/components/LeftPanel.tsx
+++ b/src/components/LeftPanel.tsx
@@ -3,13 +3,19 @@ import * as React from "react";
 import { Page } from "@shopify/polaris";
 import DumpFolderTabs from "./DumpFolderTabs";
 import SearchMethodTextField from "./SearchMethodTextField";
+import { useState } from "react";
 
 const LeftPanel: React.FunctionComponent = () => {
+  const [query, setQuery] = useState("");
+  const methodFilter = (query: string) => {
+    setQuery(query);
+  };
+
   return (
     <Page title="Graal Dump Folders">
-      <SearchMethodTextField />
+      <SearchMethodTextField methodFilter={methodFilter} />
       <br />
-      <DumpFolderTabs />
+      <DumpFolderTabs methodFilter={query} />
     </Page>
   );
 };

--- a/src/components/SearchMethodTextField.tsx
+++ b/src/components/SearchMethodTextField.tsx
@@ -1,13 +1,21 @@
 import { Button, TextField } from "@shopify/polaris";
-import React, { useCallback, useState } from "react";
+import React, { useState } from "react";
 
-export default function SearchMethodTextField() {
+interface Props {
+  methodFilter: (query: string) => void;
+}
+
+export default function SearchMethodTextField(props: Props) {
   const [textFieldValue, setTextFieldValue] = useState("");
-
-  const handleTextFieldChange = useCallback(
+  const handleTextFieldChange = React.useCallback(
     (value) => setTextFieldValue(value),
     []
   );
+
+  function handleMethodSearch() {
+    props.methodFilter(textFieldValue);
+    console.log(textFieldValue);
+  }
 
   return (
     <div>
@@ -18,7 +26,7 @@ export default function SearchMethodTextField() {
         placeholder="Example: String#[]"
       />
       <br />
-      <Button>Search</Button>
+      <Button onClick={handleMethodSearch}>Search</Button>
     </div>
   );
 }


### PR DESCRIPTION
### Issue

https://github.com/Shopify/seafoam-gui/issues/36

### Changes

The filter query is passed from the SearchBar up to the LeftPanel and into the DumpFolderTab. 
If there are no files found, there's a default `No results found.` object created message shown. Ideally, we'd create some sort of class to handle the Empty version of SeafoamNode, for example. 

Right now the search/filter is triggered by the button, but ideally, it'd also work on the Enter keystroke or as the user types the query. 

### Demo

https://user-images.githubusercontent.com/25471753/126718073-9521750a-c04a-4043-98a9-47a53c268470.mp4

