### PR TITLE
Add a new IPC event for opening the directory chooser and wire up the "Open a Folder" button to use it.

### DIFF
--- a/src/components/EmptyGraphPlaceholder.tsx
+++ b/src/components/EmptyGraphPlaceholder.tsx
@@ -1,12 +1,18 @@
 import React from "react";
 import { EmptyState } from "@shopify/polaris";
+import { openDirectoryChooser } from "../events";
 
 export default function EmptyGraphPlaceholder() {
   return (
     <EmptyState
       fullWidth
       heading="Visualize a graph"
-      action={{ content: "Open a folder" }}
+      action={{
+        content: "Open a folder",
+        onAction() {
+          openDirectoryChooser();
+        },
+      }}
       image="https://cdn.shopify.com/s/files/1/0262/4071/2726/files/emptystate-files.png"
     ></EmptyState>
   );

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,5 +1,5 @@
 import { app, ipcMain, BrowserWindow, Menu, dialog } from "electron";
-import { applicationMenu } from "./application-menu";
+import { applicationMenu, openDirectoryChooser } from "./application-menu";
 import { IPCEvents, LoadDotDataPayload, LoadPhaseDataPayload } from "../events";
 import {
   fetchCompilerPhases,
@@ -114,3 +114,16 @@ ipcMain.on(
     }
   }
 );
+
+ipcMain.on(IPCEvents.OpenDirectoryChooser, async (event) => {
+  const browserWindow = BrowserWindow.fromId(event.sender.id);
+
+  if (browserWindow) {
+    openDirectoryChooser(browserWindow);
+  } else {
+    dialog.showErrorBox(
+      "Unknown error occurred",
+      "Unable to open the system directory chooser"
+    );
+  }
+});

--- a/src/events.ts
+++ b/src/events.ts
@@ -4,6 +4,7 @@ export const enum IPCEvents {
   LoadedDotData = "loaded-dot-data",
   LoadPhaseData = "load-phase-data",
   LoadedPhaseData = "loaded-phase-data",
+  OpenDirectoryChooser = "open-directory-chooser",
 }
 
 export interface IPCPayload {
@@ -12,6 +13,7 @@ export interface IPCPayload {
   [IPCEvents.LoadedDotData]: LoadedDotDataPayload;
   [IPCEvents.LoadPhaseData]: LoadPhaseDataPayload;
   [IPCEvents.LoadedPhaseData]: LoadedPhaseDataPayload;
+  [IPCEvents.OpenDirectoryChooser]: never;
 }
 
 export interface DirectoryLoadedPayload {
@@ -47,4 +49,8 @@ export function fetchPhaseList(dumpFile: DumpFile): void {
   window.ipc_events.send(IPCEvents.LoadPhaseData, {
     filename: `${dumpFile.directory}/${dumpFile.filename}`,
   });
+}
+
+export function openDirectoryChooser(): void {
+  window.ipc_events.send(IPCEvents.OpenDirectoryChooser, []);
 }


### PR DESCRIPTION
Fixes #34: Empty state button to open folder selection.