### PR TITLE
Rework phase selection

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "main": ".webpack/main",
   "scripts": {
     "start": "electron-forge start",
+    "start:debug": "electron-forge start -- --remote-debugging-port=9229",
     "package": "electron-forge package",
     "make": "electron-forge make",
     "publish": "electron-forge publish",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,8 +2,9 @@ import * as React from "react";
 import * as ReactDOM from "react-dom";
 import LeftPanel from "./components/LeftPanel";
 import RightPanel from "./components/RightPanel";
-import { SelectedDumpFileProvider } from "./contexts/SelectedDumpFileContext";
 import { ErrorBoundary } from "./components/ErrorBoundary";
+import { GraphsLoadedProvider } from "./contexts/GraphsLoadedContext";
+import { GraphDataSourceProvider } from "./contexts/GraphDataSourceContext";
 
 const App = () => {
   // The App is tentatively split into two "sections". This is achieved by using two full-height divs, and using CSS flex
@@ -12,16 +13,18 @@ const App = () => {
   return (
     <div style={styles.app as React.CSSProperties}>
       <ErrorBoundary>
-        <SelectedDumpFileProvider>
-          <div style={styles.box as React.CSSProperties}>
-            <div style={styles.left as React.CSSProperties}>
-              <LeftPanel />
+        <GraphsLoadedProvider>
+          <GraphDataSourceProvider>
+            <div style={styles.box as React.CSSProperties}>
+              <div style={styles.left as React.CSSProperties}>
+                <LeftPanel />
+              </div>
+              <div style={styles.right as React.CSSProperties}>
+                <RightPanel />
+              </div>
             </div>
-            <div style={styles.right as React.CSSProperties}>
-              <RightPanel />
-            </div>
-          </div>
-        </SelectedDumpFileProvider>
+          </GraphDataSourceProvider>
+        </GraphsLoadedProvider>
       </ErrorBoundary>
     </div>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,8 +32,7 @@ const App = () => {
 
 const styles = {
   app: {
-    flex: 1,
-    width: "100vw",
+    flexGrow: 1,
     height: "100vh",
     flexDirection: "row",
   },
@@ -51,7 +50,7 @@ const styles = {
     width: "30vw",
   },
   right: {
-    flex: 2,
+    flexGrow: 2,
     height: "100vh",
   },
 };

--- a/src/components/DumpFolderTabs.tsx
+++ b/src/components/DumpFolderTabs.tsx
@@ -2,10 +2,10 @@ import * as React from "react";
 import { useCallback, useContext, useEffect, useState } from "react";
 import BgvFileList from "./BgvFileList";
 import { DirectoryLoadedPayload, IPCEvents } from "../events";
-import { SelectedDumpFileContext } from "../contexts/SelectedDumpFileContext";
 import { Map } from "immutable";
 import { createDumpFile } from "../lib/DumpFileUtils";
 import { Card, Tabs } from "antd";
+import { GraphsLoadedContext } from "../contexts/GraphsLoadedContext";
 
 const { TabPane } = Tabs;
 
@@ -30,7 +30,7 @@ export default function DumpFolderTabs(props: Props) {
   const [dumpDirectoryMap, setDumpDirectoryMap] = useState<DumpDirectoryMap>(
     Map({ [EMPTY_TAB_NAME]: [] })
   );
-  const { setSelectedDumpFile } = useContext(SelectedDumpFileContext);
+  const { setGraphsLoaded } = useContext(GraphsLoadedContext);
 
   useEffect(() => {
     window.ipc_events.subscribe(
@@ -47,6 +47,8 @@ export default function DumpFolderTabs(props: Props) {
             dumpDirectoryMap.set(payload.directoryName, files)
           );
         }
+
+        setGraphsLoaded(true);
       }
     );
 
@@ -87,11 +89,8 @@ export default function DumpFolderTabs(props: Props) {
     <Card>
       <Tabs onSelect={handleTabChange}>
         {tabs.map((tab) => (
-          <TabPane tab={tab.content}>
-            <BgvFileList
-              listOfBgvFiles={finalListOfBgvFiles()}
-              setSelectedFile={setSelectedDumpFile}
-            />
+          <TabPane key={tab.id} tab={tab.content}>
+            <BgvFileList listOfBgvFiles={finalListOfBgvFiles()} />
           </TabPane>
         ))}
       </Tabs>

--- a/src/components/DumpFolderTabs.tsx
+++ b/src/components/DumpFolderTabs.tsx
@@ -25,7 +25,7 @@ function buildTabs(loadedDumps: DumpDirectoryMap) {
 }
 
 export default function DumpFolderTabs(props: Props) {
-  const methodFilter: string = props.methodFilter;
+  const { methodFilter } = props;
   const [selectedTabIndex, setSelectedTabIndex] = useState(0);
   const [dumpDirectoryMap, setDumpDirectoryMap] = useState<DumpDirectoryMap>(
     Map({ [EMPTY_TAB_NAME]: [] })
@@ -64,33 +64,17 @@ export default function DumpFolderTabs(props: Props) {
 
   const tabs = buildTabs(dumpDirectoryMap);
   const tabId = tabs[selectedTabIndex]?.id;
-  const unfilteredList = dumpDirectoryMap.get(tabId) || [];
-
-  function finalListOfBgvFiles(): DumpFile[] {
-    const filteredList = unfilteredList.filter((query) =>
-      query.name.includes(methodFilter)
-    );
-    const filteredListWithNoResults =
-      filteredList.length == 0
-        ? [
-            {
-              name: "No results found.",
-              directory: "",
-              filename: "",
-              id: "",
-            },
-          ]
-        : filteredList;
-
-    return methodFilter == "" ? unfilteredList : filteredListWithNoResults;
-  }
+  const listOfBgvFiles = dumpDirectoryMap.get(tabId) || [];
 
   return (
     <Card>
       <Tabs onSelect={handleTabChange}>
         {tabs.map((tab) => (
           <TabPane key={tab.id} tab={tab.content}>
-            <BgvFileList listOfBgvFiles={finalListOfBgvFiles()} />
+            <BgvFileList
+              listOfBgvFiles={listOfBgvFiles}
+              searchQuery={methodFilter}
+            />
           </TabPane>
         ))}
       </Tabs>

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -42,7 +42,11 @@ export function GraphPanel() {
             ) : !dotData ? (
               <GraphLoading dumpFile={graphDataSource.dumpFile} />
             ) : (
-              <Graphviz dot={dotData} options={graphOptions} />
+              <Graphviz
+                className="graph-render"
+                dot={dotData}
+                options={graphOptions}
+              />
             )}
           </div>
         </Card>

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useContext, useEffect, useState } from "react";
 import { Graphviz } from "graphviz-react";
 import GraphTopBar from "./GraphTopBar";
 import { GraphLoading } from "./GraphLoading";
@@ -6,21 +6,19 @@ import { GraphvizOptions } from "d3-graphviz";
 import { fetchDotData, IPCEvents, LoadedDotDataPayload } from "../events";
 import { ChoosePhaseCTA } from "./ChoosePhaseCTA";
 import { Card } from "antd";
+import { GraphDataSourceContext } from "../contexts/GraphDataSourceContext";
 
-interface Props {
-  dumpFile: DumpFile;
-  compilerPhases: CompilerPhase[];
-}
-
-export function GraphPanel(props: Props) {
-  const { dumpFile, compilerPhases } = props;
+export function GraphPanel() {
   const [dotData, setDotData] = useState<Nullable<Dot>>(null);
-  const [phase, setPhase] = useState<Nullable<CompilerPhase>>(null);
+  const { graphDataSource } = useContext(GraphDataSourceContext);
 
   useEffect(() => {
     setDotData(null);
-    setPhase(null);
-  }, [compilerPhases, dumpFile]);
+
+    if (graphDataSource) {
+      fetchDotData(graphDataSource.dumpFile, graphDataSource.compilerPhase);
+    }
+  }, [graphDataSource]);
 
   useEffect(() => {
     window.ipc_events.subscribe(
@@ -35,22 +33,14 @@ export function GraphPanel(props: Props) {
 
   return (
     <div style={column}>
-      <GraphTopBar
-        phases={compilerPhases}
-        onPhaseChange={(phase) => {
-          setDotData(null);
-          setPhase(phase);
-
-          fetchDotData(dumpFile, phase);
-        }}
-      />
+      <GraphTopBar />
       <div style={cardContainer}>
         <Card>
           <div style={box}>
-            {!phase ? (
+            {!graphDataSource ? (
               <ChoosePhaseCTA />
             ) : !dotData ? (
-              <GraphLoading dumpFile={dumpFile} />
+              <GraphLoading dumpFile={graphDataSource.dumpFile} />
             ) : (
               <Graphviz dot={dotData} options={graphOptions} />
             )}

--- a/src/components/GraphPanel.tsx
+++ b/src/components/GraphPanel.tsx
@@ -33,7 +33,7 @@ export function GraphPanel() {
 
   return (
     <div style={column}>
-      <GraphTopBar />
+      <GraphTopBar compilerPhase={graphDataSource?.compilerPhase} />
       <div style={cardContainer}>
         <Card>
           <div style={box}>

--- a/src/components/GraphTopBar.tsx
+++ b/src/components/GraphTopBar.tsx
@@ -25,6 +25,6 @@ const row: React.CSSProperties = {
 };
 
 const search = {
-  flex: 2,
-  padding: 16,
+  flexGrow: 2,
+  padding: "16px",
 };

--- a/src/components/GraphTopBar.tsx
+++ b/src/components/GraphTopBar.tsx
@@ -1,39 +1,11 @@
 import React from "react";
-import { Input, Select } from "antd";
+import { Input } from "antd";
 
 const { Search } = Input;
 
-export interface Props {
-  phases: CompilerPhase[];
-  onPhaseChange: (phase: CompilerPhase) => void;
-}
-
-export default function GraphTopBar(props: Props) {
-  const { onPhaseChange, phases } = props;
-
-  const handleSelectPhaseChange = React.useCallback(
-    (value) => {
-      const phaseNumber = parseInt(value);
-
-      onPhaseChange(phases[phaseNumber]);
-    },
-    [phases]
-  );
-
+export default function GraphTopBar() {
   return (
     <div style={row}>
-      <div style={picker}>
-        <Select
-          placeholder="<Select Compiler Phase>"
-          onChange={handleSelectPhaseChange}
-          options={phases.map((phase, index) => {
-            return {
-              label: phase.name,
-              value: index.toString(),
-            };
-          })}
-        />
-      </div>
       <div style={search}>
         <Search onSearch={() => alert("Not yet implemented")} />
       </div>
@@ -50,11 +22,6 @@ const row: React.CSSProperties = {
   width: "60vw",
   alignItems: "flex-end",
   justifyContent: "space-around",
-};
-
-const picker = {
-  flex: 1,
-  padding: 16,
 };
 
 const search = {

--- a/src/components/GraphTopBar.tsx
+++ b/src/components/GraphTopBar.tsx
@@ -1,11 +1,23 @@
 import React from "react";
-import { Input } from "antd";
+import { Input, Typography } from "antd";
 
 const { Search } = Input;
+const { Title } = Typography;
 
-export default function GraphTopBar() {
+interface Props {
+  compilerPhase?: CompilerPhase;
+}
+
+export default function GraphTopBar(props: Props) {
+  const { compilerPhase } = props;
+
   return (
     <div style={row}>
+      {compilerPhase && (
+        <Title
+          level={5}
+        >{`${compilerPhase.method}: ${compilerPhase.name} (${compilerPhase.number})`}</Title>
+      )}
       <div style={search}>
         <Search onSearch={() => alert("Not yet implemented")} />
       </div>
@@ -14,17 +26,10 @@ export default function GraphTopBar() {
 }
 
 const row: React.CSSProperties = {
-  flexGrow: 0,
-  flexShrink: 1,
-  flexBasis: "auto",
-  display: "flex",
-  flexDirection: "row",
   width: "60vw",
-  alignItems: "flex-end",
-  justifyContent: "space-around",
 };
 
 const search = {
-  flexGrow: 2,
-  padding: "16px",
+  marginBottom: "16px",
+  marginTop: "16px",
 };

--- a/src/components/RightPanel.tsx
+++ b/src/components/RightPanel.tsx
@@ -1,48 +1,18 @@
 import * as React from "react";
-import { useContext, useEffect, useState } from "react";
+import { useContext } from "react";
 
 import EmptyGraphPlaceholder from "./EmptyGraphPlaceholder";
-import { fetchPhaseList, IPCEvents, LoadedPhaseDataPayload } from "../events";
-import { SelectedDumpFileContext } from "../contexts/SelectedDumpFileContext";
 import { GraphPanel } from "./GraphPanel";
 import { Card } from "antd";
+import { GraphsLoadedContext } from "../contexts/GraphsLoadedContext";
 
 const RightPanel: React.FunctionComponent = () => {
-  const { selectedDumpFile } = useContext(SelectedDumpFileContext);
-  const [phases, setPhases] = useState<Nullable<CompilerPhase[]>>(null);
-
-  useEffect(() => {
-    setPhases(null);
-  }, [selectedDumpFile]);
-
-  useEffect(() => {
-    window.ipc_events.subscribe(
-      IPCEvents.LoadedPhaseData,
-      (payload: LoadedPhaseDataPayload) => {
-        setPhases(payload.phases);
-      }
-    );
-
-    return () => window.ipc_events.unsubscribe(IPCEvents.LoadedPhaseData);
-  }, []);
-
-  useEffect(() => {
-    if (selectedDumpFile) {
-      fetchPhaseList(selectedDumpFile);
-    }
-  }, [selectedDumpFile]);
+  const { graphsLoaded } = useContext(GraphsLoadedContext);
 
   return (
     <div className="right-hand-panel">
       <Card title="Graph Panel">
-        {selectedDumpFile ? (
-          <GraphPanel
-            dumpFile={selectedDumpFile}
-            compilerPhases={phases ?? []}
-          />
-        ) : (
-          <EmptyGraphPlaceholder />
-        )}
+        {graphsLoaded ? <GraphPanel /> : <EmptyGraphPlaceholder />}
       </Card>
     </div>
   );

--- a/src/contexts/GraphDataSourceContext.tsx
+++ b/src/contexts/GraphDataSourceContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, PropsWithChildren, useState } from "react";
+
+interface GraphDataSource {
+  dumpFile: DumpFile;
+  compilerPhase: CompilerPhase;
+}
+
+export interface ContextObject {
+  graphDataSource: Nullable<GraphDataSource>;
+  setGraphDataSource: (dataSource: GraphDataSource) => void;
+}
+
+export const GraphDataSourceContext = createContext<ContextObject>({
+  graphDataSource: null,
+  setGraphDataSource: () => null,
+});
+
+export function GraphDataSourceProvider(props: PropsWithChildren<unknown>) {
+  const [graphDataSource, setGraphDataSource] =
+    useState<Nullable<GraphDataSource>>(null);
+
+  return (
+    <GraphDataSourceContext.Provider
+      value={{ graphDataSource, setGraphDataSource }}
+    >
+      {props.children}
+    </GraphDataSourceContext.Provider>
+  );
+}

--- a/src/contexts/GraphsLoadedContext.tsx
+++ b/src/contexts/GraphsLoadedContext.tsx
@@ -1,0 +1,21 @@
+import React, { PropsWithChildren } from "react";
+
+export interface ContextObject {
+  graphsLoaded: boolean;
+  setGraphsLoaded: (filesLoaded: boolean) => void;
+}
+
+export const GraphsLoadedContext = React.createContext<ContextObject>({
+  graphsLoaded: false,
+  setGraphsLoaded: () => void 0,
+});
+
+export function GraphsLoadedProvider(props: PropsWithChildren<unknown>) {
+  const [graphsLoaded, setGraphsLoaded] = React.useState(false);
+
+  return (
+    <GraphsLoadedContext.Provider value={{ graphsLoaded, setGraphsLoaded }}>
+      {props.children}
+    </GraphsLoadedContext.Provider>
+  );
+}

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -45,8 +45,8 @@ if (require("electron-squirrel-startup")) {
 const createWindow = (): void => {
   // Create the browser window.
   const mainWindow = new BrowserWindow({
-    height: 600,
-    width: 800,
+    height: 768,
+    width: 1024,
     webPreferences: {
       preload: MAIN_WINDOW_PRELOAD_WEBPACK_ENTRY,
     },
@@ -56,7 +56,7 @@ const createWindow = (): void => {
   mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
 
   // Open the DevTools.
-  mainWindow.webContents.openDevTools();
+  //mainWindow.webContents.openDevTools();
 };
 
 // This method will be called when Electron has finished
@@ -114,6 +114,19 @@ ipcMain.on(
     }
   }
 );
+
+ipcMain.handle(IPCEvents.LoadPhaseData, async (event, payload) => {
+  const { filename } = payload;
+
+  try {
+    const data = await fetchCompilerPhases(filename);
+
+    return { phases: data };
+  } catch (e) {
+    handleSeafoamCommandError(e, "Error fetching compiler phases");
+    return [];
+  }
+});
 
 ipcMain.on(IPCEvents.OpenDirectoryChooser, async (event) => {
   const browserWindow = BrowserWindow.fromId(event.sender.id);

--- a/src/electron/preload.ts
+++ b/src/electron/preload.ts
@@ -7,7 +7,12 @@
 // renderer process.
 
 import { contextBridge, ipcRenderer } from "electron";
-import { IPCEvents, IPCPayload } from "../events";
+import {
+  IPCEvents,
+  IPCPayload,
+  LoadedPhaseDataPayload,
+  LoadPhaseDataPayload,
+} from "../events";
 import ElectronLog from "electron-log";
 
 // Enable IPC logging (must be configured here to work in the renderer process).
@@ -44,12 +49,17 @@ export interface IPC<Event extends IPCEvents> {
   ) => void;
   unsubscribe: (event: Event) => void;
   send: (event: Event, payload: IPCPayload[Event]) => void;
+  fetchPhases: (
+    payload: LoadPhaseDataPayload
+  ) => Promise<LoadedPhaseDataPayload>;
 }
 
 contextBridge.exposeInMainWorld("ipc_events", {
   subscribe: subscribe,
   unsubscribe: unsubscribe,
   send: send,
+  fetchPhases: (payload: LoadPhaseDataPayload) =>
+    ipcRenderer.invoke(IPCEvents.LoadPhaseData, payload),
 });
 
 contextBridge.exposeInMainWorld("logger", ElectronLog);

--- a/src/index.css
+++ b/src/index.css
@@ -25,3 +25,7 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+.ant-tree-indent {
+  display: none;
+}


### PR DESCRIPTION
Switch the two-part phase selection to using a tree of phases beneath each method. This makes the UI more compact and simplifies some of the state management code.